### PR TITLE
Add shell completions with topic autocomplete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,8 +176,20 @@ checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.6",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+ "clap_lex 1.1.0",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -197,6 +209,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -518,6 +536,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1140,6 +1167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,9 +1402,10 @@ dependencies = [
 
 [[package]]
 name = "taskbeep"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
+ "clap_complete",
  "crossterm",
  "ctrlc",
  "daemonize",
@@ -1693,6 +1727,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1724,11 +1767,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1744,6 +1804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,6 +1820,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1768,10 +1840,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1786,6 +1870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +1886,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1810,6 +1906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1922,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "taskbeep"
 authors = ["J. Adly <youssefadly237@gmail.com>"]
 repository = "https://github.com/youssefadly237/taskbeep"
 description = "TaskBeep - Pomodoro Timer with Productivity Tracking"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 readme = "README.md"
 license = "MIT"
@@ -27,3 +27,4 @@ toml = "0.9.11"
 time = { version = "0.3", features = ["local-offset"] }
 ratatui = { version = "0.30.0", optional = true, default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.29.0", optional = true }
+clap_complete = { version = "4.6.2", features = ["unstable-dynamic"] }

--- a/README.md
+++ b/README.md
@@ -354,6 +354,28 @@ taskbeep config --reset
 cat $(taskbeep config --path)
 ```
 
+### Shell Completions
+
+Enable tab-completion for your shell:
+
+```bash
+# Bash
+echo "source <(COMPLETE=bash taskbeep)" >> ~/.bashrc
+
+# Zsh
+echo "source <(COMPLETE=zsh taskbeep)" >> ~/.zshrc
+
+# Fish
+echo "COMPLETE=fish taskbeep | source" >> ~/.config/fish/config.fish
+```
+
+Or generate static scripts:
+
+```bash
+taskbeep completions bash > /tmp/taskbeep.bash
+source /tmp/taskbeep.bash
+```
+
 ## Installation
 
 ```bash

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,102 @@
+use std::ffi::OsStr;
+
+use clap::CommandFactory;
+use clap_complete::engine::CompletionCandidate;
+use clap_complete::env::CompleteEnv;
+
+use crate::Cli;
+use crate::stats::read_stats_entries;
+
+fn topic_candidates(current: &str, mut topics: Vec<String>) -> Vec<String> {
+    topics.sort();
+    topics.dedup();
+
+    if current.is_empty() {
+        return topics;
+    }
+
+    let current_lower = current.to_lowercase();
+
+    topics
+        .into_iter()
+        .filter(|t| t.to_lowercase().contains(&current_lower))
+        .collect()
+}
+
+fn get_all_topics() -> Vec<String> {
+    match read_stats_entries(None) {
+        Ok(entries) => entries.into_iter().map(|e| e.topic).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+pub(crate) fn topic_completer(current: &OsStr) -> Vec<CompletionCandidate> {
+    let current = current.to_str().unwrap_or("");
+    topic_candidates(current, get_all_topics())
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+pub fn configure_completions() {
+    CompleteEnv::with_factory(|| {
+        let mut cmd = Cli::command();
+        cmd.build();
+
+        // Keep built-in meta entries at the bottom of completion results.
+        cmd = cmd
+            .mut_arg("help", |arg| arg.display_order(usize::MAX - 1))
+            .mut_arg("version", |arg| arg.display_order(usize::MAX));
+
+        cmd = cmd.mut_subcommand("help", |sub| sub.display_order(usize::MAX));
+        cmd
+    })
+    .bin("taskbeep")
+    .complete();
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+    use clap_complete::engine::ArgValueCompleter;
+
+    use crate::Cli;
+
+    use super::topic_candidates;
+
+    #[test]
+    fn topic_candidates_are_sorted_and_deduped() {
+        let topics = topic_candidates(
+            "",
+            vec!["beta".to_string(), "alpha".to_string(), "beta".to_string()],
+        );
+
+        assert_eq!(topics, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn topic_candidates_match_case_insensitively() {
+        let topics = topic_candidates(
+            "AL",
+            vec!["alpha".to_string(), "beta".to_string(), "delta".to_string()],
+        );
+
+        assert_eq!(topics, vec!["alpha"]);
+    }
+
+    #[test]
+    fn start_topic_has_custom_completer() {
+        let mut command = Cli::command();
+        command.build();
+        let start = command
+            .get_subcommands()
+            .find(|cmd: &&clap::Command| cmd.get_name() == "start")
+            .expect("start subcommand should exist");
+        let topic = start
+            .get_positionals()
+            .find(|arg: &&clap::Arg| arg.get_index() == Some(1))
+            .expect("start topic positional should exist");
+
+        assert!(topic.get::<ArgValueCompleter>().is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod audio;
 mod commands;
+mod completions;
 mod config;
 mod error;
 mod heatmap;
@@ -10,7 +11,8 @@ mod timer;
 mod ui;
 mod utils;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::engine::ArgValueCompleter;
 use config::Config;
 use std::{path::PathBuf, sync::OnceLock};
 
@@ -60,6 +62,7 @@ enum Commands {
     /// Start a Pomodoro timer with a topic and interval in seconds (configurable default)
     Start {
         /// The topic/task you're working on
+        #[arg(add = ArgValueCompleter::new(completions::topic_completer))]
         topic: String,
         /// Interval in seconds (default from config or 1500s/25 minutes)
         interval: Option<u64>,
@@ -67,31 +70,39 @@ enum Commands {
         #[arg(long)]
         response_timeout: Option<u64>,
     },
-    /// Stop and end the timer process
-    Stop {
-        /// Mark the stopped session as working time
-        #[arg(long, conflicts_with = "wasting")]
-        working: bool,
-        /// Mark the stopped session as wasting time
-        #[arg(long, conflicts_with = "working")]
-        wasting: bool,
+    /// Clear statistics (all or for a specific topic)
+    Clear {
+        /// Optional topic to delete (if omitted, deletes all statistics)
+        topic: Option<String>,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+    /// Generate static shell completion scripts (no runtime topic list)
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_name = "SHELL")]
+        shell: clap_complete::Shell,
+    },
+    /// Manage configuration (show settings, view path, or reset to defaults)
+    Config {
+        /// Show the path to the config file
+        #[arg(long)]
+        path: bool,
+        /// Reset configuration to defaults
+        #[arg(long)]
+        reset: bool,
+    },
+    /// Export statistics to a file (default: ./taskbeep_stats.tsv)
+    Export {
+        /// Output file path
+        #[arg(default_value = "taskbeep_stats.tsv")]
+        output: PathBuf,
     },
     /// Pause the timer temporarily
     Pause,
     /// Resume the paused timer
     Resume,
-    /// Toggle between pause and resume
-    Toggle,
-    /// Show current timer status
-    Status {
-        /// Output format: human (default), json, or plain
-        #[arg(short, long, default_value = "human")]
-        format: String,
-    },
-    /// Signal that you were working on the topic
-    Working,
-    /// Signal that you were wasting time
-    Wasting,
     /// Show productivity statistics
     Stats {
         /// Only show stats for this topic
@@ -115,34 +126,34 @@ enum Commands {
         #[arg(long)]
         heatmap: bool,
     },
+    /// Show current timer status
+    Status {
+        /// Output format: human (default), json, or plain
+        #[arg(short, long, default_value = "human")]
+        format: String,
+    },
+    /// Stop and end the timer process
+    Stop {
+        /// Mark the stopped session as working time
+        #[arg(long, conflicts_with = "wasting")]
+        working: bool,
+        /// Mark the stopped session as wasting time
+        #[arg(long, conflicts_with = "working")]
+        wasting: bool,
+    },
+    /// Toggle between pause and resume
+    Toggle,
     /// Open interactive one-page terminal UI
     Ui,
-    /// Export statistics to a file (default: ./taskbeep_stats.tsv)
-    Export {
-        /// Output file path
-        #[arg(default_value = "taskbeep_stats.tsv")]
-        output: PathBuf,
-    },
-    /// Clear statistics (all or for a specific topic)
-    Clear {
-        /// Optional topic to delete (if omitted, deletes all statistics)
-        topic: Option<String>,
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
-    },
-    /// Manage configuration (show settings, view path, or reset to defaults)
-    Config {
-        /// Show the path to the config file
-        #[arg(long)]
-        path: bool,
-        /// Reset configuration to defaults
-        #[arg(long)]
-        reset: bool,
-    },
+    /// Signal that you were wasting time
+    Wasting,
+    /// Signal that you were working on the topic
+    Working,
 }
 
 fn main() {
+    completions::configure_completions();
+
     let cli = Cli::parse();
 
     let result = match cli.command {
@@ -233,6 +244,15 @@ fn main() {
                 );
                 Ok(())
             }
+        }
+        Commands::Completions { shell } => {
+            clap_complete::aot::generate(
+                shell,
+                &mut Cli::command(),
+                "taskbeep",
+                &mut std::io::stdout(),
+            );
+            Ok(())
         }
     };
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -40,6 +40,8 @@ enum UiMode {
     },
     StartInput {
         value: String,
+        search_query: String,
+        selected_index: usize,
     },
     RangeInput {
         start: String,
@@ -262,9 +264,22 @@ impl App {
                 }
                 Ok(false)
             }
-            UiMode::StartInput { mut value } => {
-                if self.handle_text_input_key(code, &mut value, false)? {
-                    self.mode = UiMode::StartInput { value };
+            UiMode::StartInput {
+                mut value,
+                mut search_query,
+                mut selected_index,
+            } => {
+                if self.handle_start_input_key(
+                    code,
+                    &mut value,
+                    &mut search_query,
+                    &mut selected_index,
+                )? {
+                    self.mode = UiMode::StartInput {
+                        value,
+                        search_query,
+                        selected_index,
+                    };
                 }
                 Ok(false)
             }
@@ -346,6 +361,8 @@ impl App {
                 self.clear_error();
                 self.mode = UiMode::StartInput {
                     value: String::new(),
+                    search_query: String::new(),
+                    selected_index: 0,
                 };
             }
             KeyCode::Char('t') => {
@@ -430,6 +447,102 @@ impl App {
             }
             _ => Ok(true),
         }
+    }
+
+    fn handle_start_input_key(
+        &mut self,
+        code: KeyCode,
+        value: &mut String,
+        search_query: &mut String,
+        selected_index: &mut usize,
+    ) -> Result<bool> {
+        let matches = self.get_matching_topics(search_query);
+
+        match code {
+            KeyCode::Esc => {
+                self.clear_error();
+                self.mode = UiMode::Normal;
+                Ok(false)
+            }
+            KeyCode::Enter => {
+                let topic = if !value.is_empty() {
+                    value.clone()
+                } else if let Some(t) = matches.first().cloned() {
+                    t
+                } else {
+                    self.set_error("no topic selected".to_string());
+                    return Ok(true);
+                };
+                match self.start_timer_from_ui(topic) {
+                    Ok(true) => {}
+                    Ok(false) => return Ok(true),
+                    Err(error) => {
+                        self.set_error(format!("start failed: {error}"));
+                        return Ok(true);
+                    }
+                }
+                self.mode = UiMode::Normal;
+                Ok(false)
+            }
+            KeyCode::Up => {
+                let total_options = 1 + matches.len();
+                if total_options > 1 {
+                    if *selected_index == 0 {
+                        *selected_index = total_options - 1;
+                    } else {
+                        *selected_index -= 1;
+                    }
+                    if *selected_index == 0 {
+                        *value = search_query.clone();
+                    } else if let Some(topic) = matches.get(*selected_index - 1).cloned() {
+                        *value = topic;
+                    }
+                }
+                Ok(true)
+            }
+            KeyCode::Down => {
+                let total_options = 1 + matches.len();
+                if total_options > 1 {
+                    *selected_index = (*selected_index + 1) % total_options;
+                    if *selected_index == 0 {
+                        *value = search_query.clone();
+                    } else if let Some(topic) = matches.get(*selected_index - 1).cloned() {
+                        *value = topic;
+                    }
+                }
+                Ok(true)
+            }
+            KeyCode::Backspace => {
+                if !search_query.is_empty() {
+                    search_query.pop();
+                    *selected_index = 0;
+                    *value = search_query.clone();
+                }
+                Ok(true)
+            }
+            KeyCode::Char(c) => {
+                search_query.push(c);
+                *selected_index = 0;
+                *value = search_query.clone();
+                Ok(true)
+            }
+            _ => Ok(true),
+        }
+    }
+
+    fn get_matching_topics(&self, input: &str) -> Vec<String> {
+        let mut topics: Vec<String> = if input.is_empty() {
+            self.all_entries.iter().map(|e| e.topic.clone()).collect()
+        } else {
+            self.all_entries
+                .iter()
+                .filter(|e| topic_matches(input, &e.topic))
+                .map(|e| e.topic.clone())
+                .collect()
+        };
+        topics.sort();
+        topics.dedup();
+        topics
     }
 
     fn handle_stop_confirm_key(&mut self, code: KeyCode) -> Result<bool> {
@@ -656,6 +769,16 @@ impl App {
     }
 
     fn footer_notice_line(&self) -> Line<'_> {
+        if let UiMode::StartInput { search_query, .. } = &self.mode {
+            let matches = self.get_matching_topics(search_query);
+            if matches.is_empty() && !search_query.is_empty() {
+                return Line::from(vec![Span::styled(
+                    "no matching topics",
+                    Style::default().fg(Color::DarkGray),
+                )]);
+            }
+        }
+
         match &self.footer_notice {
             Some(FooterNotice {
                 kind: NoticeKind::Error,
@@ -946,7 +1069,7 @@ impl App {
 
     fn timer_title(&self) -> Line<'_> {
         match &self.mode {
-            UiMode::StartInput { value } => {
+            UiMode::StartInput { value, .. } => {
                 let mut spans = framed_label("Timer");
                 spans.extend(framed_prompt(
                     's',

--- a/tests/e2e_smoke.rs
+++ b/tests/e2e_smoke.rs
@@ -44,6 +44,19 @@ impl TestEnv {
             .expect("failed to execute taskbeep")
     }
 
+    fn run_completion(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_taskbeep"))
+            .args(args)
+            .env("COMPLETE", "bash")
+            // Index 2 is the third token: the topic argument in "taskbeep start <TAB>".
+            .env("_CLAP_COMPLETE_INDEX", "2")
+            .env("_CLAP_COMPLETE_SPACE", "true")
+            .env("XDG_RUNTIME_DIR", &self.runtime_dir)
+            .env("HOME", &self.home_dir)
+            .output()
+            .expect("failed to execute taskbeep completion")
+    }
+
     fn run_ok(&self, args: &[&str]) -> Output {
         let output = self.run(args);
         assert!(
@@ -122,6 +135,36 @@ fn daemon_socket_cli_smoke_flow() {
         field_count, 7,
         "stats entry has unexpected field count: {} ({})",
         field_count, first_line
+    );
+}
+
+#[test]
+fn env_completion_returns_topics_for_start() {
+    let env = TestEnv::new();
+
+    fs::write(
+        &env.stats_path,
+        "1000\t2000\t1000\t0\t0\tHIC-211\tworking\n1000\t2000\t1000\t0\t0\ttyping\tworking\n",
+    )
+    .expect("failed to seed stats file");
+
+    let output = env.run_completion(&["--", "taskbeep", "start", ""]);
+    assert!(
+        output.status.success(),
+        "completion command failed: exit: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("HIC-211"),
+        "missing topic completion: {stdout}"
+    );
+    assert!(
+        stdout.contains("--help"),
+        "missing help completion: {stdout}"
     );
 }
 


### PR DESCRIPTION
- add shell completions via `clap_complete`
- support dynamic topic autocomplete from stats
- add `taskbeep completions <shell>` command
- improve TUI start input (topic completions)
- add tests for completion behavior
- bump version to `v0.3.1`

closes #19 